### PR TITLE
Bugfix: do not explode warnings when `group_loc` is `null`

### DIFF
--- a/src/main/java/api/messages/GoblintMessagesResult.java
+++ b/src/main/java/api/messages/GoblintMessagesResult.java
@@ -92,7 +92,7 @@ public class GoblintMessagesResult {
          * @return A collection of AnalysisResult objects.
          */
         public List<AnalysisResult> convert(List<Tag> tags, String severity, boolean explode) {
-            return explode
+            return explode && this.group_loc != null
                     ? convertGroupExplode(tags, severity)
                     : convertGroup(tags, severity);
         }


### PR DESCRIPTION
Fixes the bug found in #6